### PR TITLE
Add stream support to rpc.

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -252,7 +252,9 @@ type Method struct {
 	InTypeName, OutTypeName string
 	InType, OutType         interface{}
 
-	// TODO: support streaming methods
+	// ClientStreaming and ServerStreaming indicate whether the argument and
+	// return value to the rpc are streams.
+	ClientStreaming, ServerStreaming bool
 
 	Up *Service
 }

--- a/gendesc/gendesc.go
+++ b/gendesc/gendesc.go
@@ -279,6 +279,12 @@ func genMethod(mth *ast.Method) (*pb.MethodDescriptorProto, error) {
 		InputType:  proto.String(qualifiedName(mth.InType)),
 		OutputType: proto.String(qualifiedName(mth.OutType)),
 	}
+	if mth.ClientStreaming {
+		mdp.ClientStreaming = proto.Bool(true)
+	}
+	if mth.ServerStreaming {
+		mdp.ServerStreaming = proto.Bool(true)
+	}
 	return mdp, nil
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -787,6 +787,19 @@ func (p *parser) readService(srv *ast.Service) *parseError {
 			return tok.err
 		}
 		mth.InTypeName = tok.value // TODO: validate
+		if tok.value == "stream" {
+			// If the next token isn't ")", this is a stream.
+			tok = p.next()
+			if tok.err != nil {
+				return tok.err
+			}
+			if tok.value != ")" {
+				mth.InTypeName = tok.value
+				mth.ClientStreaming = true
+			} else {
+				p.back()
+			}
+		}
 		if err := p.readToken(")"); err != nil {
 			return err
 		}
@@ -802,6 +815,19 @@ func (p *parser) readService(srv *ast.Service) *parseError {
 		}
 		mth.OutTypeName = tok.value // TODO: validate
 
+		if tok.value == "stream" {
+			// If the next token isn't ")", this is a stream.
+			tok = p.next()
+			if tok.err != nil {
+				return tok.err
+			}
+			if tok.value != ")" {
+				mth.OutTypeName = tok.value
+				mth.ServerStreaming = true
+			} else {
+				p.back()
+			}
+		}
 		if err := p.readToken(")"); err != nil {
 			return err
 		}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -335,6 +335,18 @@ var parseTests = []parseTest{
 			`message_type:{name:"In"} message_type:{name:"Out"}`,
 	},
 	{
+		"SimpleServiceWithMessageCalledStream",
+		"service TestService {\n  rpc Foo(stream) returns (stream);\n}\n message stream {}",
+		`service { name: "TestService" method { name:"Foo" input_type:".stream" output_type:".stream" } }` +
+			`message_type:{name:"stream"}`,
+	},
+	{
+		"StreamingService",
+		"service TestService {\n  rpc Foo(stream In) returns (stream Out);\n}\n message In{} message Out{}",
+		`service { name: "TestService" method { name:"Foo" input_type:".In" output_type:".Out" client_streaming: true server_streaming: true } }` +
+			`message_type:{name:"In"} message_type:{name:"Out"}`,
+	},
+	{
 		"ParseImport",
 		"import \"foo/bar/baz.proto\";\n",
 		`dependency: "foo/bar/baz.proto"`,


### PR DESCRIPTION
Add support for client and server streaming.

Example:
```
service Serv {
	rpc Foo(stream Bar) returns (stream Baz);
}
```